### PR TITLE
Check files are JS before attempting to require()

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,8 +25,11 @@
       files.forEach(function(filename) {
   
         if ((filename === 'index.js') || (filename[0] === '_')) { return; }
+
+        var ext = path.extname(filename);
+        if (!(ext in require.extensions)) { return; }
     
-        filename = path.basename(filename, path.extname(filename));
+        filename = path.basename(filename, ext);
         var filepath = path.join(dir, filename);
     
         requires[filename] = require(path.resolve(filepath));


### PR DESCRIPTION
I had an issue with swap files attempting to be required. This is a simple change which just checks that what is about to be required is in the list of extensions which can be processed by `require()`.
