### PR TITLE
remove asserts dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,9 +25,6 @@
   "engines": {
     "node": ">=0.10.5"
   },
-  "devDependencies": {
-    "asserts": "4.0.x"
-  },
   "author": "Stephen Handley <stephen.handley@gmail.com> (http://person.sh)",
   "homepage": "https://github.com/stephenhandley/requireindex"
 }

--- a/test/test.js
+++ b/test/test.js
@@ -1,43 +1,25 @@
-var Assert = require('assert');
-var Asserts = require('asserts');
+'use strict'
 
-Asserts(function () {
-  var lib = require('./lib');
+var assert = require('assert');
+var lib = require('./lib');
 
-  return {
-    "requireindex should": {
-      "properly include files parallel to index.js and maintain structure": function () {
-        Asserts.all.equal([
-          [lib.bam.m,            [], "ok"],
-          [lib.bar.f,            [], "yea"],
-          [lib.bar.fing,         [], 'definitely'],
-          [lib.Foo.l,            [], 'yes'],
-          [lib.Foo.ls,           [], 'yep'],
-          [lib.bam.n,            [], 'ack'],
-          [lib.bar.fed.again,    [], 'again'],
-          [lib.bar.fed.somemore, [], 'somemore']
-        ]);
-      },
+assert.equal(lib.bam.m(), 'ok', 'requireindex should properly include files parallel to index.js and maintain structure');
+assert.equal(lib.bar.f(), 'yea', 'requireindex should properly include files parallel to index.js and maintain structure');
+assert.equal(lib.bar.fing(), 'definitely', 'requireindex should properly include files parallel to index.js and maintain structure');
+assert.equal(lib.Foo.l(), 'yes', 'requireindex should properly include files parallel to index.js and maintain structure');
+assert.equal(lib.Foo.ls(), 'yep', 'requireindex should properly include files parallel to index.js and maintain structure');
+assert.equal(lib.bam.n(), 'ack', 'requireindex should properly include files parallel to index.js and maintain structure');
+assert.equal(lib.bar.fed.again(), 'again', 'requireindex should properly include files parallel to index.js and maintain structure');
+assert.equal(lib.bar.fed.somemore(), 'somemore', 'requireindex should properly include files parallel to index.js and maintain structure');
 
-      "ignore _ prefixed files": function () {
-        Assert.equal(('_private' in lib), false);
-      },
+assert.equal('_private' in lib, false, 'ignore _ prefixed files');
 
-      "not include files not mentioned when second array argument is used": function () {
-        Assert.equal(('ignored' in lib.bar.fed), false);
-      },
+assert.equal('ignored' in lib.bar.fed, false, 'not include files not mentioned when second array argument is used');
 
-      "ignore non javascript files": function () {
-        Assert.equal(('not_javascript' in lib), false);
-      },
+assert.equal('not_javascript' in lib, false, 'ignore non javascript files');
 
-      "sort files by lowercase alpha of the filename": function () {
-        Assert.equal(Object.keys(lib)[0], 'bam');
-      },
-      
-      "ignore dot files": function () {
-        Assert.equal(('.also_private' in lib), false);
-      },
-    }
-  };
-});
+assert.equal(Object.keys(lib)[0], 'bam', 'sort files by lowercase alpha of the filename /1');
+assert.equal(Object.keys(lib)[1], 'bar', 'sort files by lowercase alpha of the filename /2');
+assert.equal(Object.keys(lib)[2], 'Foo', 'sort files by lowercase alpha of the filename /3');
+
+assert.equal('.also_private' in lib, false, 'ignore dot files');


### PR DESCRIPTION
Remove asserts dev dependency as it wont will download with node 0.10.5 on ubuntu-latest and macos. 

![image](https://user-images.githubusercontent.com/5059100/203019327-639e2ef3-2878-41e8-bc02-f16429bce8d9.png)
